### PR TITLE
Use published container image and improve networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ meshtastic --get serial
 ## Quick Start
 
 ```bash
-# Build the image
-docker build -t meshtastic-serial-bridge -f src/Dockerfile src/
-
-# Start the bridge
+# Start the bridge (automatically pulls latest image)
 docker compose up -d
 
 # Test it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,11 @@
 
 services:
   serial-bridge:
-    image: meshtastic-serial-bridge
+    image: ghcr.io/yeraze/meshtastic-serial-bridge:latest
     container_name: serial-bridge
-    network_mode: host  # Allows localhost TCP communication
     restart: unless-stopped
+    ports:
+      - "4403:4403"
     devices:
       - /dev/ttyUSB0:/dev/ttyUSB0
     volumes:


### PR DESCRIPTION
## Summary
- Switch `docker-compose.yml` to use published image `ghcr.io/yeraze/meshtastic-serial-bridge:latest`
- Replace host networking with standard port mapping (`4403:4403`)
- Simplify Quick Start instructions (no build step required)

## Benefits
- **Easier deployment**: Users can `docker compose up` without building locally
- **Better Docker practices**: Uses standard port mapping instead of `network_mode: host`
- **Automatic updates**: Pulling `:latest` gets newest published version
- **Smaller attack surface**: Container doesn't need full host network access

## Testing
✅ Pulled image successfully from ghcr.io  
✅ Container starts with port mapping `0.0.0.0:4403->4403/tcp`  
✅ meshtastic CLI connects successfully via `--host localhost`  
✅ All features working: HUPCL disabled, mDNS registered, socat bridge active

## Files Changed
- `docker-compose.yml`: Use published image + port mapping
- `README.md`: Removed build step from Quick Start

🤖 Generated with [Claude Code](https://claude.com/claude-code)